### PR TITLE
Changes regular expression matching headings to allow white space before...

### DIFF
--- a/toc.js
+++ b/toc.js
@@ -25,7 +25,7 @@ function processData(data) {
     var minDepth = 1000000;
     for(var i = 0; i < lines.length; i++) {
         var line = lines[i];
-        var m = line.match(/^\s*(#+)(.*)$/);
+        var m = line.match(/^\s*(#+)(.*)\s*$/);
         if (!m) continue;
         minDepth = Math.min(minDepth, m[1].length);
         depths.push(m[1].length);


### PR DESCRIPTION
I had white space after text and before new line character in my markdown's headings. So the regular expression would not match any heading at all.
I changed the regular expression to allow matching headings with (or without) white space before end of line.
Please review.
Thank you in advance.
