### PR TITLE
Improve compatibility with some Markdown renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ md-toc-filter -d 2 README.md > NEW_README.md
 ```
 This will include headings up to depth 2 (##).
 
+Pass the `-a` argument to use an alternative link generation mode, e.g. convert
+the heading "3.1.1. Foo" to "3-1-1-foo" instead of "311-foo". This argument will
+also strip all the non-Latin and non-numeric characters. This is useful for some
+Markdown renderers like the GitLab Markdown renderer.
 ## Example
 
 ```

--- a/toc.js
+++ b/toc.js
@@ -5,6 +5,10 @@ var program = require('commander');
 
 program.version("0.9.0")
        .option("-d, --depth <n>", "Specifies the maximal header depth for the TOC", parseInt)
+       .option("-a, --alternativeLinks", "Use alternative links for headings.\n" +
+                                        "\tE.g. 1.1. Foo will become 1-1-foo instead of 11-foo. This option also\n" +
+                                        "\tstrips all non-Latin and non-numeric characters from the URLs. Useful for\n" +
+                                        "\tsome Markdown flavors like the GitLab Flavored Markdown")
        .parse(process.argv);
 
 var FOUR_SPACES = "    ";
@@ -73,12 +77,16 @@ function createTOC(depths, titles) {
 }
 
 function titleToUrl(title) {
-    return title.trim()
-                .replace(/[a-z]+/ig, function(match) {
-                    return match.toLowerCase();
-                })
-                .replace(/\s/g, '-')
-                .replace(/[^-0-9a-zа-яё]/ig, '');
+    var trimmedTitle = title.trim()
+                            .replace(/[a-z]+/ig, function(match) {
+                                return match.toLowerCase();
+                            });
+    if (program.alternativeLinks) {
+        return trimmedTitle.replace(/[^0-9a-z]+/ig, '-');
+    } else {
+        return trimmedTitle.replace(/\s/g, '-')
+                           .replace(/[^-0-9a-zа-яё]/ig, '');
+    }
 }
 
 function tocLine(depth, title) {


### PR DESCRIPTION
Some Markdown flavors (e.g. GitLab Favored Markdown) convert headers
to URLs replacing all characters which are not Latin and numeric
with "-". This change improves the compatibility with them through
adding an "-a" argument option which generates headers for these
Markdown flavors.

This change pulls the commander Node.js module as a dependency.
