### PR TITLE
Allow maximal heading depth do be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Then, preprocess the file:
 md-toc-filter README.md > NEW_README.md
 ```
 
+You can also specify the maximal heading depth to be included in the TOC by
+passing the `-d` argument:
+```
+md-toc-filter -d 2 README.md > NEW_README.md
+```
+This will include headings up to depth 2 (##).
+
 ## Example
 
 ```

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
       "type" : "git"
     , "url" : "https://github.com/aslushnikov/table-of-contents-preprocessor"
   }
+  , "dependencies": {
+      "commander": "2.3.0"
+  }
   , "engines" : { "node" : ">=0.6.14" }
   , "private": false
 }

--- a/toc.js
+++ b/toc.js
@@ -1,16 +1,25 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
+var program = require('commander');
+
+program.version("0.9.0")
+       .option("-d, --depth <n>", "Specifies the maximal header depth for the TOC", parseInt)
+       .parse(process.argv);
 
 var FOUR_SPACES = "    ";
 
 var leftIndents = [""];
 
+if(process.argv.length < 3) {
+    program.help();
+}
+
 for(var i = 1; i < 10; i++) {
     leftIndents.push(leftIndents[i-1] + FOUR_SPACES);
 }
 
-fs.readFile(process.argv[2], 'utf-8', function(err, data) {
+fs.readFile(process.argv[process.argv.length-1], 'utf-8', function(err, data) {
     if (err) {
         throw err;
     }
@@ -25,11 +34,10 @@ function processData(data) {
     var minDepth = 1000000;
     for(var i = 0; i < lines.length; i++) {
         var line = lines[i];
-        var m = line.match(/^(#+)(.*)\s*$/);
-        if (!m) continue;
-        minDepth = Math.min(minDepth, m[1].length);
-        depths.push(m[1].length);
-        titles.push(m[2]);
+        var headingLine = line.match(/^(#+)(.*)\s*$/);
+        if (!headingLine) continue;
+        minDepth = Math.min(minDepth, headingLine[1].length);
+        addHeadingLine(headingLine, depths, titles);
     }
 
     for(var i = 0; i < depths.length; i++) {
@@ -47,6 +55,13 @@ function processData(data) {
     }
     console.log(lines.join('\n'));
     //console.log('\n');
+}
+
+function addHeadingLine(headingLine, depths, titles) {
+    if(program.depth >= headingLine[1].length || !program.depth) {
+        depths.push(headingLine[1].length);
+        titles.push(headingLine[2]);
+    }
 }
 
 function createTOC(depths, titles) {


### PR DESCRIPTION
Adds the -d argument taking a number specifying the maximal heading
depth to be included in the table of contents.

This change pulls the commander Node.js module as a dependency.
